### PR TITLE
Long uchar vector for data representation

### DIFF
--- a/pqkmeans/clustering/pqkmeans.py
+++ b/pqkmeans/clustering/pqkmeans.py
@@ -18,7 +18,7 @@ class PQKMeans(sklearn.base.BaseEstimator, sklearn.base.ClusterMixin):
     def fit(self, x_train):
         #type (typing.Iterable[typing.Iterable[numpy.uint8]]) -> None
         assert len(x_train.shape) == 2
-        self._impl.fit(x_train)
+        self._impl.fit(x_train.reshape(-1)) # Convert to a long 1D array
 
     def predict(self, x_test):
         # type: (numpy.array) -> Any

--- a/src/clustering/pqkmeans.h
+++ b/src/clustering/pqkmeans.h
@@ -13,13 +13,26 @@
 namespace pqkmeans {
 
 
+
+
+class UcharVecs {
+public:
+    UcharVecs() {init_ = false;}
+
+    bool init_;
+};
+
+
+
+
+
 class PQKMeans {
 public:
     PQKMeans(std::vector<std::vector<std::vector<float>>> codewords, int K, int itr, bool verbose);
 
     int predict_one(const std::vector<unsigned char> &pyvector);
 
-    void fit(const std::vector<std::vector<unsigned char>> &pydata);
+    void fit(const std::vector<unsigned char> &pydata);  // pydata is a long array. pydata.size == N * M
 
     const std::vector<int> GetAssignments();
 
@@ -31,6 +44,7 @@ private:
     int K_;
     int itr_;
     std::size_t M_; // the number of subspace
+    std::size_t N_; // The number of vectors to be clusted in fit
     bool verbose_;
 
     std::vector<std::vector<unsigned char>> centers_;  // centers for clustering.
@@ -46,7 +60,7 @@ private:
     float L2SquaredDistance(const std::vector<float> &vec1,
                             const std::vector<float> &vec2);
 
-    void InitializeCentersByRandomPicking(const std::vector<std::vector<unsigned char>> &codes,
+    void InitializeCentersByRandomPicking(const std::vector<unsigned char> &codes,  // codes.size == N * M
                                           int K,
                                           std::vector<std::vector<unsigned char>> *centers_);
 
@@ -56,8 +70,14 @@ private:
 
     // Compute a new cluster center from assigned codes. codes: All N codes. selected_ids: selected assigned ids.
     // e.g., If selected_ids=[4, 25, 13], then codes[4], codes[25], and codes[13] are averaged by the proposed sparse voting scheme.
-    std::vector<unsigned char> ComputeCenterBySparseVoting(const std::vector<std::vector<unsigned char>> &codes,
+    std::vector<unsigned char> ComputeCenterBySparseVoting(const std::vector<unsigned char> &codes,  // codes.size == N * M
                                                            const std::vector<std::size_t> &selected_ids);
+
+    // Given a long (N * M) codes, pick up n-th code
+    std::vector<unsigned char> NthCode(const std::vector<unsigned char> &long_code, std::size_t n);
+
+    // Given a long (N * M) codes, pick up m-th element from n-th code
+    unsigned char NthCodeMthElement(const std::vector<unsigned char> &long_code, std::size_t n, int m);
 
 };
 

--- a/src/clustering/pqkmeans.h
+++ b/src/clustering/pqkmeans.h
@@ -12,20 +12,6 @@
 
 namespace pqkmeans {
 
-
-
-
-class UcharVecs {
-public:
-    UcharVecs() {init_ = false;}
-
-    bool init_;
-};
-
-
-
-
-
 class PQKMeans {
 public:
     PQKMeans(std::vector<std::vector<std::vector<float>>> codewords, int K, int itr, bool verbose);
@@ -44,7 +30,6 @@ private:
     int K_;
     int itr_;
     std::size_t M_; // the number of subspace
-    std::size_t N_; // The number of vectors to be clusted in fit
     bool verbose_;
 
     std::vector<std::vector<unsigned char>> centers_;  // centers for clustering.


### PR DESCRIPTION
- Changed the PQcode representation, from vector-of-vector (`vec<vec<uchar>>`) to one-long-vector  (`vec<uchar>`) for memory-efficient search.
- N-th code can be accessed by NthCode(code, n)
- M-the element of N-th code can be accessed by NthCodeMthElement(code, n, m)