### PR TITLE
Remove a nested class in pqencoder

### DIFF
--- a/pqkmeans/encoder/pq_encoder.py
+++ b/pqkmeans/encoder/pq_encoder.py
@@ -5,33 +5,6 @@ from .encoder_base import EncoderBase
 
 
 class PQEncoder(EncoderBase):
-    class TrainedPQEncoder(object):
-        def __init__(self, codewords, code_dtype):
-            # type: (numpy.array, type) -> None
-            self.codewords, self.code_dtype = codewords, code_dtype
-            self.M, _, self.Ds = codewords.shape
-
-        def encode_multi(self, data_matrix):
-            data_matrix = numpy.array(data_matrix)
-            N, D = data_matrix.shape
-            assert self.Ds * self.M == D, "input dimension must be Ds * M"
-
-            codes = numpy.empty((N, self.M), dtype=self.code_dtype)
-            for m in range(self.M):
-                codes[:, m], _ = vq(data_matrix[:, m * self.Ds: (m + 1) * self.Ds], self.codewords[m])
-            return codes
-
-        def decode_multi(self, codes):
-            codes = numpy.array(codes)
-            N, M = codes.shape
-            assert M == self.M
-            assert codes.dtype == self.code_dtype
-
-            decoded = numpy.empty((N, self.Ds * self.M), dtype=numpy.float)
-            for m in range(self.M):
-                decoded[:, m * self.Ds: (m + 1) * self.Ds] = self.codewords[m][codes[:, m], :]
-            return decoded
-
     def __init__(self, iteration=20, num_subdim=4, Ks=256):
         # type: (int, int, int) -> None
         assert Ks <= 2 ** 32
@@ -53,7 +26,7 @@ class PQEncoder(EncoderBase):
         for m in range(self.M):
             x_train_sub = x_train[:, m * self.Ds: (m + 1) * self.Ds].astype(numpy.float)
             codewords[m], _ = kmeans2(x_train_sub, self.Ks, iter=self.iteration, minit='points')
-        self.trained_encoder = self.TrainedPQEncoder(codewords, self.code_dtype)
+        self.trained_encoder = TrainedPQEncoder(codewords, self.code_dtype)
 
     def transform_generator(self, x_test):
         # type: (typing.Iterable[typing.Iterator[float]]) -> Any
@@ -69,3 +42,31 @@ class PQEncoder(EncoderBase):
     def codewords(self):
         assert self.trained_encoder is not None, "This PQEncoder instance is not fitted yet. Call 'fit' with appropriate arguments before using this method."
         return self.trained_encoder.codewords
+
+
+class TrainedPQEncoder(object):
+    def __init__(self, codewords, code_dtype):
+        # type: (numpy.array, type) -> None
+        self.codewords, self.code_dtype = codewords, code_dtype
+        self.M, _, self.Ds = codewords.shape
+        
+    def encode_multi(self, data_matrix):
+        data_matrix = numpy.array(data_matrix)
+        N, D = data_matrix.shape
+        assert self.Ds * self.M == D, "input dimension must be Ds * M"
+        
+        codes = numpy.empty((N, self.M), dtype=self.code_dtype)
+        for m in range(self.M):
+            codes[:, m], _ = vq(data_matrix[:, m * self.Ds: (m + 1) * self.Ds], self.codewords[m])
+        return codes
+    
+    def decode_multi(self, codes):
+        codes = numpy.array(codes)
+        N, M = codes.shape
+        assert M == self.M
+        assert codes.dtype == self.code_dtype
+        
+        decoded = numpy.empty((N, self.Ds * self.M), dtype=numpy.float)
+        for m in range(self.M):
+            decoded[:, m * self.Ds: (m + 1) * self.Ds] = self.codewords[m][codes[:, m], :]
+        return decoded


### PR DESCRIPTION
- PQEncoder cannot be pickled in Python2 because it has a nested class (TrainedPQEncoder)
- This PR simply makes TrainedPQEncoder out of the PQEncoder
- This should resolve #12 