### PR TITLE
:memo: version 1.0.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='pqkmeans',
-    version='1.0.1',
+    version='1.0.2',
     author='Keisuke Ogaki, Yusuke Matsui',
     author_email='keisuke_ogaki@dwango.co.jp, matsui528@gmail.com',
     license='MIT License',


### PR DESCRIPTION
Updated setup.py to version 1.0.2 for pip. (Removed the nested class in PQEncoder for Python2 compatibility #13 )