### PR TITLE
extend pqkmeans constructor to take initial cluster center

### DIFF
--- a/pqkmeans/clustering/pqkmeans.py
+++ b/pqkmeans/clustering/pqkmeans.py
@@ -6,9 +6,11 @@ import _pqkmeans
 
 
 class PQKMeans(sklearn.base.BaseEstimator, sklearn.base.ClusterMixin):
-    def __init__(self, encoder, k, iteration=10, verbose=False):
+    def __init__(self, encoder, k, iteration=10, verbose=False, init_centers=None):
         super(PQKMeans, self).__init__()
-        self._impl = _pqkmeans.PQKMeans(encoder.codewords, k, iteration, verbose)
+        if init_centers is None:
+            init_centers = []
+        self._impl = _pqkmeans.PQKMeans(encoder.codewords, k, iteration, verbose, init_centers)
 
     def predict_generator(self, x_test):
         #type (typing.Iterable[typing.Iterable[numpy.uint8]]) -> Any

--- a/src/_pqkmeans.cpp
+++ b/src/_pqkmeans.cpp
@@ -28,7 +28,7 @@ PYBIND11_MODULE(_pqkmeans, m) {
             .def_property_readonly("cluster_centers_", &BKMeans::GetClusterCenters);
 
     py::class_<PQKMeans>(m, "PQKMeans")
-            .def(py::init< std::vector<std::vector<std::vector<float>>>, int, int, bool >())
+            .def(py::init< std::vector<std::vector<std::vector<float>>>, int, int, bool, std::vector<std::vector<unsigned char>>>())
             .def("fit", &PQKMeans::fit)
             .def("predict_one", &PQKMeans::predict_one)
             .def_property_readonly("labels_", &PQKMeans::GetAssignments)

--- a/src/clustering/pqkmeans.cpp
+++ b/src/clustering/pqkmeans.cpp
@@ -19,6 +19,7 @@ PQKMeans::PQKMeans(std::vector<std::vector<std::vector<float> > > codewords, int
         throw;
     }
 
+    // In case of not using cluster center initialization, it gots empty vector.
     if (initial_centers.size() > 0){
         SetClusterCenters(initial_centers);
     }
@@ -145,7 +146,7 @@ std::vector<std::vector<unsigned char>> PQKMeans::GetClusterCenters()
     return centers_;
 }
 
-void PQKMeans::SetClusterCenters(std::vector<std::vector<unsigned char>> centers_new)
+void PQKMeans::SetClusterCenters(const std::vector<std::vector<unsigned char>> centers_new)
 {
     assert(centers_new.size() == K_);
     centers_ = centers_new;

--- a/src/clustering/pqkmeans.cpp
+++ b/src/clustering/pqkmeans.cpp
@@ -3,7 +3,7 @@
 namespace pqkmeans {
 
 
-PQKMeans::PQKMeans(std::vector<std::vector<std::vector<float> > > codewords, int K, int itr, bool verbose)
+PQKMeans::PQKMeans(std::vector<std::vector<std::vector<float> > > codewords, int K, int itr, bool verbose, std::vector<std::vector<unsigned char>> initial_centers)
     : codewords_(codewords), K_(K), itr_(itr), verbose_(verbose)
 {
     assert(!codewords.empty() && !codewords[0].empty() && !codewords[0][0].empty());
@@ -13,10 +13,14 @@ PQKMeans::PQKMeans(std::vector<std::vector<std::vector<float> > > codewords, int
 
     if (256 < Ks) {
         std::cerr << "Error. Ks is too large. "
-                  << "Currently, we support PQ code with Ks <= 256 "
+                  << "Currently, we only support PQ code with Ks <= 256 "
                   << "so that each subspace is represented by unsigned char (8 bit)"
                   << std::endl;
         throw;
+    }
+
+    if (initial_centers.size() > 0){
+        SetClusterCenters(init_centers)
     }
 
     // Compute distance-matrices among codewords
@@ -140,6 +144,13 @@ std::vector<std::vector<unsigned char>> PQKMeans::GetClusterCenters()
 {
     return centers_;
 }
+
+void PQKMeans::SetClusterCenters(std::vector<std::vector<unsigned char>> centers_new)
+{
+    assert(centers_new.size() == K_)
+    centers_ = centers_new
+}
+
 
 float PQKMeans::SymmetricDistance(const std::vector<unsigned char> &code1,
                                   const std::vector<unsigned char> &code2)

--- a/src/clustering/pqkmeans.cpp
+++ b/src/clustering/pqkmeans.cpp
@@ -146,7 +146,7 @@ std::vector<std::vector<unsigned char>> PQKMeans::GetClusterCenters()
     return centers_;
 }
 
-void PQKMeans::SetClusterCenters(const std::vector<std::vector<unsigned char>> centers_new)
+void PQKMeans::SetClusterCenters(const std::vector<std::vector<unsigned char>> &centers_new)
 {
     assert(centers_new.size() == K_);
     centers_ = centers_new;

--- a/src/clustering/pqkmeans.cpp
+++ b/src/clustering/pqkmeans.cpp
@@ -20,7 +20,7 @@ PQKMeans::PQKMeans(std::vector<std::vector<std::vector<float> > > codewords, int
     }
 
     if (initial_centers.size() > 0){
-        SetClusterCenters(init_centers)
+        SetClusterCenters(initial_centers);
     }
 
     // Compute distance-matrices among codewords
@@ -147,8 +147,8 @@ std::vector<std::vector<unsigned char>> PQKMeans::GetClusterCenters()
 
 void PQKMeans::SetClusterCenters(std::vector<std::vector<unsigned char>> centers_new)
 {
-    assert(centers_new.size() == K_)
-    centers_ = centers_new
+    assert(centers_new.size() == K_);
+    centers_ = centers_new;
 }
 
 

--- a/src/clustering/pqkmeans.h
+++ b/src/clustering/pqkmeans.h
@@ -14,7 +14,7 @@ namespace pqkmeans {
 
 class PQKMeans {
 public:
-    PQKMeans(std::vector<std::vector<std::vector<float>>> codewords, int K, int itr, bool verbose);
+    PQKMeans(std::vector<std::vector<std::vector<float>>> codewords, int K, int itr, bool verbose, std::vector<std::vector<unsigned char>> initial_centers);
 
     int predict_one(const std::vector<unsigned char> &pyvector);
 
@@ -45,6 +45,7 @@ private:
     float L2SquaredDistance(const std::vector<float> &vec1,
                             const std::vector<float> &vec2);
 
+    void SetClusterCenters(std::vector<std::vector<unsigned char>> centers_new);
     void InitializeCentersByRandomPicking(const std::vector<unsigned char> &codes,  // codes.size == N * M
                                           int K,
                                           std::vector<std::vector<unsigned char>> *centers_);

--- a/src/clustering/pqkmeans.h
+++ b/src/clustering/pqkmeans.h
@@ -45,7 +45,7 @@ private:
     float L2SquaredDistance(const std::vector<float> &vec1,
                             const std::vector<float> &vec2);
 
-    void SetClusterCenters(std::vector<std::vector<unsigned char>> centers_new);
+    void SetClusterCenters(const std::vector<std::vector<unsigned char>> &centers_new);
     void InitializeCentersByRandomPicking(const std::vector<unsigned char> &codes,  // codes.size == N * M
                                           int K,
                                           std::vector<std::vector<unsigned char>> *centers_);

--- a/test/clustering/test_pqkmeans.py
+++ b/test/clustering/test_pqkmeans.py
@@ -53,18 +53,18 @@ class TestPQKMeans(unittest.TestCase):
                 numpy.linalg.norm(cluster_centers_decoded[other_cluster] - code_decoded)
             )
     def test_constructor_with_cluster_center(self):
-        # Run pqkmeans first. 
+        # Run pqkmeans first.
         engine = pqkmeans.clustering.PQKMeans(encoder=self.encoder, k=5, iteration=10, verbose=False)
         codes = self.encoder.transform(numpy.array(list(self.data_source(100))))
         fit_predicted = engine.fit_predict(codes)
         cluster_centers = numpy.array(engine.cluster_centers_, dtype=numpy.uint8)
         predicted = engine.predict(codes)
 
-        # Create new pqkmeans, but construct with initial centers. 
-        engine_recovered = pqkmeans.clustering.PQKMeans(encoder=self.encoder, k=5, iteration=10, verbose=False, init_centers=cluster_centers)        
-        fit_predicted_from_recovered_obj = engine_recovered.predict(codes)        
+        # Create new pqkmeans, but construct with initial centers.
+        engine_recovered = pqkmeans.clustering.PQKMeans(encoder=self.encoder, k=5, iteration=10, verbose=False, init_centers=cluster_centers)
+        fit_predicted_from_recovered_obj = engine_recovered.predict(codes)
 
-        self.assertEqual(predicted.all(), fit_predicted_from_recovered_obj.all())
+        numpy.testing.assert_array_equal(predicted, fit_predicted_from_recovered_obj)
 
 
 

--- a/test/clustering/test_pqkmeans.py
+++ b/test/clustering/test_pqkmeans.py
@@ -52,6 +52,19 @@ class TestPQKMeans(unittest.TestCase):
                 numpy.linalg.norm(cluster_centers_decoded[cluster] - code_decoded),
                 numpy.linalg.norm(cluster_centers_decoded[other_cluster] - code_decoded)
             )
+    def test_constructor_with_cluster_center(self):
+        # Run pqkmeans first. 
+        engine = pqkmeans.clustering.PQKMeans(encoder=self.encoder, k=5, iteration=10, verbose=False)
+        codes = self.encoder.transform(numpy.array(list(self.data_source(100))))
+        fit_predicted = engine.fit_predict(codes)
+        cluster_centers = numpy.array(engine.cluster_centers_, dtype=numpy.uint8)
+        predicted = engine.predict(codes)
+
+        # Create new pqkmeans, but construct with initial centers. 
+        engine_recovered = pqkmeans.clustering.PQKMeans(encoder=self.encoder, k=5, iteration=10, verbose=False, init_centers=cluster_centers)        
+        fit_predicted_from_recovered_obj = engine_recovered.predict(codes)        
+
+        self.assertEqual(predicted.all(), fit_predicted_from_recovered_obj.all())
 
 
 


### PR DESCRIPTION
* Python PQKmeans class optionally take initial cluster centers
    * initial centers are in PQcode that is consistent with the given encoder
    * the number of initial centers must be the same as the given k
    * saving in PQcode rather than original vector save spaces and convenient for development

