### PR TITLE
Remove dependency upon `typing'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ numpy
 scikit-learn
 pipe
 scipy
-typing
 six
 texmex_python==1.0.0


### PR DESCRIPTION
As per https://pypi.org/project/typing/ - this module is not needed for Python >= 3.5 . Actually, it can also cause problems in newer versions of Python since it shadows the built in typing module, but it not compatible e.g.:

```
      File "venv/lib/python3.8/site-packages/typing.py", line 1359, in <module>
        class Callable(extra=collections_abc.Callable, metaclass=CallableMeta):
      File "venv/lib/python3.8/site-packages/typing.py", line 1007, in __new__
        self._abc_registry = extra._abc_registry
    AttributeError: type object 'Callable' has no attribute '_abc_registry'
```

This PR just removes the dependency.