### PR TITLE
Fix some dependencies for easy installation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       max-parallel: 3
       matrix:
         platform: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       max-parallel: 3
       matrix:
         platform: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       max-parallel: 3
       matrix:
         platform: [ubuntu-latest]
-        python-version: [3.5, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ python setup.py install
 
 
 ```
+# evaluation needs extra texmex package
+pip install pqkmeans[texmex]
 # with artificial data
 python bin/run_experiment.py --dataset artificial --algorithm bkmeans pqkmeans --k 100
 # with texmex dataset (http://corpus-texmex.irisa.fr/)

--- a/pqkmeans/evaluation.py
+++ b/pqkmeans/evaluation.py
@@ -3,7 +3,10 @@ import numpy
 import os
 import six.moves.urllib
 import tarfile
-import texmex_python
+try:
+    import texmex_python
+except ImportError:
+    pass
 
 
 def get_gmm_random_dataset(k, dimension=100, test_size=5000, train_size=500):

--- a/pqkmeans/evaluation.py
+++ b/pqkmeans/evaluation.py
@@ -3,10 +3,6 @@ import numpy
 import os
 import six.moves.urllib
 import tarfile
-try:
-    import texmex_python
-except ImportError:
-    pass
 
 
 def get_gmm_random_dataset(k, dimension=100, test_size=5000, train_size=500):
@@ -42,6 +38,10 @@ def get_sift1m_dataset(cache_directory="."):
 
 
 def get_texmex_dataset(url, filename, member_names, cache_directory="."):
+    try:
+        import texmex_python
+    except ImportError:
+        raise ImportError("Missing optional dependency 'texmex_python'. You must install it to use this dataset.")
     path = os.path.join(cache_directory, filename)
     if not os.path.exists(path):
         print("downloading {}".format(url))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-numpy
+numpy<1.21
 scikit-learn
-pipe
+pipe<2.0
 scipy
 six
-texmex_python==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -92,4 +92,7 @@ The library is written in C++ for the main algorithm with wrappers for Python. A
     cmdclass=dict(build_ext=CMakeBuild),
     test_suite='test',
     zip_safe=False,
+    extras_require={
+        "texmex": ["texmex-python>=1.0.0"],
+    },
 )


### PR DESCRIPTION
# Problem

https://github.com/DwangoMediaVillage/pqkmeans/issues/46

The old library lshash3 is preventing easy installation of pqkmeans. This library is depended on by texmex-python.

# Solution

Move texmex-python to the extras_require section.
Of course, you can also `pip install pqkmeans[texmex]` (or `pip install -e . [texmex]`) to install it with texmex.

